### PR TITLE
Fixed scipy.sparse.linalg._eigen.arpack.arpack.ArpackNoConvergence: ARPACK error -1: No convergence

### DIFF
--- a/rescompy/rescompy.py
+++ b/rescompy/rescompy.py
@@ -570,11 +570,18 @@ class ESN:
         # Create the adjacency matrix A.
         def rvs(size):
             return rng.uniform(low=-1, high=1, size=size)
-        A = sparse.random(size, size, density=connections/size,
-                          random_state=rng, data_rvs=rvs)
-        v0 = rng.random(size)
-        eigenvalues, _ = splinalg.eigs(A, k=1, v0=v0)
-        A *= spectral_radius/np.abs(eigenvalues[0])
+        # TODO: This needs a better fix.
+        done = False
+        while not done:
+            try:
+                A = sparse.random(size, size, density=connections/size,
+                                  random_state=rng, data_rvs=rvs)
+                v0 = rng.random(size)
+                eigenvalues, _ = splinalg.eigs(A, k=1, v0=v0)
+                A *= spectral_radius/np.abs(eigenvalues[0])
+                done = True
+            except:
+                print ("failed to calculate SR, trying again...")
 
         # Create input matrix B.
         if isinstance(input_strength, float):


### PR DESCRIPTION
This error is due to the scipy.sparse.linalg routine failing to calculate to calculate the spectral radius when normalizing W.
It normally occurs when calculating spectral radii many times in a row, such as when optimizing an ESN.
Using scipy.sparse.linalg routine is still preferable because it is fast with the sparse matrices that we use for W and because it is repeatable subject to a fixed seed.
This fix simply to "try again" when the routine fails.